### PR TITLE
Fix out-of-range error at TimelineEditorTrack setup

### DIFF
--- a/lib/timeline_editor_track.dart
+++ b/lib/timeline_editor_track.dart
@@ -253,7 +253,7 @@ class _TimelineEditorTrackState extends State<TimelineEditorTrack> {
   void setup() {
     List<ITimelineEditorCard> targetBoxes = List<ITimelineEditorCard>();
 
-    if (widget.boxes != null) {
+    if (widget.boxes != null && widget.boxes.length > 0) {
       var sortedStart = widget.boxes.toList();
       sortedStart.sort((a, b) => a.start.compareTo(b.start));
       var blankFirstBox = TimelineEditorEmptyCard(


### PR DESCRIPTION
This PR fixes #12 

When empty boxes list is provided, it ends with out-of-range error when accesses element at position 0. Extra condition is added to fix that.