### PR TITLE
Customizable timelineeditortrack action icons

### DIFF
--- a/lib/timeline_editor_track.dart
+++ b/lib/timeline_editor_track.dart
@@ -20,6 +20,9 @@ class TimelineEditorCard extends ITimelineEditorCard {
   /// background color of this box
   final Color color;
 
+  /// optional border color when selected
+  final Color borderColor;
+
   /// optional [PopupMenuEntry] list to display if a user long press this box
   final List<PopupMenuEntry> menuEntries;
 
@@ -51,6 +54,7 @@ class TimelineEditorCard extends ITimelineEditorCard {
       this.onTap,
       this.child,
       this.color,
+      this.borderColor,
       this.menuEntries,
       this.onSelectedMenuItem,
       this.onMovedDuration,
@@ -81,7 +85,7 @@ class TimelineEditorCard extends ITimelineEditorCard {
               Positioned.fill(
                 child: Container(
                   decoration: BoxDecoration(
-                    border: Border.all(color: Colors.white, width: 6),
+                    border: Border.all(color: borderColor != null ? borderColor : Colors.white, width: 6),
                   ),
                 ),
               ),
@@ -95,7 +99,7 @@ class TimelineEditorCard extends ITimelineEditorCard {
                     height: 30,
                     width: 30,
                     child: Container(
-                      color: Colors.white,
+                      color: borderColor != null ? borderColor : Colors.white,
                       child: onMovedDurationIcon != null 
                       ? onMovedDurationIcon 
                       : Icon(
@@ -116,7 +120,7 @@ class TimelineEditorCard extends ITimelineEditorCard {
                     height: 30,
                     width: 30,
                     child: Container(
-                      color: Colors.white,
+                      color: borderColor != null ? borderColor : Colors.white,
                       child: onMovedStartIcon != null 
                       ? onMovedStartIcon 
                       : Icon(
@@ -139,7 +143,7 @@ class TimelineEditorCard extends ITimelineEditorCard {
                       return menuEntries;
                     },
                     child: Container(
-                      color: Colors.white,
+                      color: borderColor != null ? borderColor : Colors.white,
                       child: menuEntriesIcon != null 
                       ? menuEntriesIcon 
                       : Icon(

--- a/lib/timeline_editor_track.dart
+++ b/lib/timeline_editor_track.dart
@@ -34,6 +34,15 @@ class TimelineEditorCard extends ITimelineEditorCard {
   /// possibility of moving this box
   final void Function(Duration duration) onMovedStart;
 
+  /// optional icon for [onMovedStart]
+  final Icon onMovedStartIcon;
+
+  /// optional icon for [onMovedDuration]
+  final Icon onMovedDurationIcon;
+
+  /// optional icon for [menuEntries]
+  final Icon menuEntriesIcon;
+
   const TimelineEditorCard(Duration start,
       {Key key,
       Duration duration,
@@ -45,7 +54,10 @@ class TimelineEditorCard extends ITimelineEditorCard {
       this.menuEntries,
       this.onSelectedMenuItem,
       this.onMovedDuration,
-      this.onMovedStart})
+      this.onMovedStart,
+      this.onMovedStartIcon,
+      this.onMovedDurationIcon,
+      this.menuEntriesIcon})
       : super(key: key, start: start, duration: duration);
 
   @override
@@ -84,7 +96,9 @@ class TimelineEditorCard extends ITimelineEditorCard {
                     width: 30,
                     child: Container(
                       color: Colors.white,
-                      child: Icon(
+                      child: onMovedDurationIcon != null 
+                      ? onMovedDurationIcon 
+                      : Icon(
                         Icons.swap_horiz,
                         color: Colors.black,
                       ),
@@ -103,7 +117,9 @@ class TimelineEditorCard extends ITimelineEditorCard {
                     width: 30,
                     child: Container(
                       color: Colors.white,
-                      child: Icon(
+                      child: onMovedStartIcon != null 
+                      ? onMovedStartIcon 
+                      : Icon(
                         Icons.swap_horiz,
                         color: Colors.black,
                       ),
@@ -124,7 +140,9 @@ class TimelineEditorCard extends ITimelineEditorCard {
                     },
                     child: Container(
                       color: Colors.white,
-                      child: Icon(
+                      child: menuEntriesIcon != null 
+                      ? menuEntriesIcon 
+                      : Icon(
                         Icons.menu,
                         color: Colors.black,
                       ),


### PR DESCRIPTION
This PR fixes issue #9 

I added ability to add custom icons for tile menu and both drag ends. Since it have to have colour set to black in order to works, it was logical to add also border colour setting in same PR.

All those extra parameters are optional and if not set, it will reverts to original behaviour.